### PR TITLE
If applied this commit will unset the entity-clone rel link

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,14 @@ As we know, delete this HTML head links was improve SEO for your CMS Drupal 8.x 
 <link rel="version-history" href="/node/1/revisions">
 <link rel="revision" href="/page-1-name">
 <link rel="canonical" href="http://example.com/">
+<link rel="clone-form" href="/entity_clone/taxonomy_term/1234" />
 ```
 
 Support for:
 
 * Nodes
 * Taxonomy terms
+* Entity Clone
 
 ### Install module
 

--- a/unset_html_head_link.module
+++ b/unset_html_head_link.module
@@ -42,7 +42,8 @@ function _remove_header_links(array &$attachments) {
     'drupal:content-translation-edit',
     'drupal:content-translation-delete',
     'shortlink',
-    'canonical'
+    'canonical',
+    'clone-form'
   ];
   // Unset loop.
   foreach ($attachments['#attached']['html_head_link'] as $key => $value) {


### PR DESCRIPTION
The module entity clone inserts a rel link like

`<link rel="clone-form" href="/entity_clone/taxonomy_term/29" /> `

This PR adds support to the unset html head link module for entity clone to get rid of this needless rel attribute. 